### PR TITLE
Fix firestore rules compilation errors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,13 +45,13 @@ service cloud.firestore {
     }
     
     function isMatchScorer(matchId) {
-      let match = get(/databases/$(database)/documents/Matches/$(matchId));
-      return match != null && match.data.current_scorer_id == getUserId();
+      let matchDoc = get(/databases/$(database)/documents/Matches/$(matchId));
+      return matchDoc != null && matchDoc.data.current_scorer_id == getUserId();
     }
     
     function isInMatchPool(matchId) {
-      let match = get(/databases/$(database)/documents/Matches/$(matchId));
-      return match != null && isPoolMember(match.data.pool_id);
+      let matchDoc = get(/databases/$(database)/documents/Matches/$(matchId));
+      return matchDoc != null && isPoolMember(matchDoc.data.pool_id);
     }
     
     // Users collection - users can only read/write their own document


### PR DESCRIPTION
Rename `match` variable to `matchDoc` in Firestore rules to resolve compilation errors caused by using a reserved keyword.

The `match` keyword is reserved in Firestore security rules for path matching. Using it as a variable name in helper functions led to `Unexpected 'match'` and `mismatched input 'match' expecting IDENTIFIER` compilation errors during deployment. Renaming the variable avoids this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad7039e3-c711-47a1-9cca-31f9206ff156">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad7039e3-c711-47a1-9cca-31f9206ff156">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>